### PR TITLE
fix flacky by sort return value 

### DIFF
--- a/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngine.groovy
+++ b/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngine.groovy
@@ -162,6 +162,7 @@ class CheckDuplicateClassesEngine {
                 moduleMessages.add(message)
             }
         }
+        moduleMessages.sort()
 
         return moduleMessages.join('\n')
     }

--- a/src/test/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngineTest.groovy
+++ b/src/test/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngineTest.groovy
@@ -31,10 +31,10 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
             "\n" +
             "test\n" +
             "    axiom-dom.jar, axiom-impl.jar\n" +
-            "    javax.transaction-api-1.3.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar\n" +
-            "    jakarta.activation-api-1.2.1.jar, javax.activation-api-1.2.0.jar\n" +
+            "    geronimo-jta_1.1_spec-1.1.1.jar, javax.transaction-api-1.3.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar\n"+
             "    geronimo-jta_1.1_spec-1.1.1.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar\n" +
-            "    geronimo-jta_1.1_spec-1.1.1.jar, javax.transaction-api-1.3.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar"
+            "    jakarta.activation-api-1.2.1.jar, javax.activation-api-1.2.0.jar\n" +
+            "    javax.transaction-api-1.3.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar" 
 
     private Map<String, Set<String>> classesByJar
 


### PR DESCRIPTION
### Description

Fixed the flaky test `testSearchForDuplicates` inside the `CheckDuplicateClassesEngineTest` class.

**Root Cause**
The test `testSearchForDuplicates` has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed because it is trying to compare two strings, but the tested method uses `each` to go through a Collection generate a list, and then convert the list to a string. The `each` method in Groovy is implemented in such a way that it does not go through every element in a Collection in a specific order. As a result, when the expected string(which is hard-coded) is compared with the actual one, it causes the failure.

**Fix**
The test is fixed by sorting the list generated in the tested method before converting it to a string and changing the expected string to meet the sorting order. Therefore, the order of context in both the expected string and the generated string is the same. 

### How this has been tested?

1. Regular test - Successful
Command used -
```
./gradlew --info test --tests net.idlestate.gradle.duplicates.CheckDuplicateClassesEngineTest.testSearchForDuplicates
```

2. NonDex test - Failed
Command used -
```
./gradlew --info nondexTest --tests=net.idlestate.gradle.duplicates.CheckDuplicateClassesEngineTest.testSearchForDuplicates --nondexRuns=X
```
replace X with a int number
NonDex test passed after the fix.

