### PR TITLE
fix testExcldeJarFiles

### DIFF
--- a/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngine.groovy
+++ b/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngine.groovy
@@ -162,6 +162,7 @@ class CheckDuplicateClassesEngine {
                 moduleMessages.add(message)
             }
         }
+        moduleMessages.sort()
 
         return moduleMessages.join('\n')
     }

--- a/src/test/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngineTest.groovy
+++ b/src/test/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngineTest.groovy
@@ -68,9 +68,10 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
             "\n" +
             "test\n" +
             "    axiom-dom.jar, axiom-impl.jar\n" +
-            "    javax.transaction-api-1.3.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar\n" +
+            "    geronimo-jta_1.1_spec-1.1.1.jar, javax.transaction-api-1.3.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar\n" +
             "    geronimo-jta_1.1_spec-1.1.1.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar\n" +
-            "    geronimo-jta_1.1_spec-1.1.1.jar, javax.transaction-api-1.3.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar"
+            "    javax.transaction-api-1.3.jar, jboss-transaction-api_1.2_spec-1.0.1.Final.jar" 
+
 
     @Test
     void testExcludeJarFiles() {


### PR DESCRIPTION
### Description

Fixed the flaky test `testExcludeJarFiles` inside the `CheckDuplicateClassesEngineTest` class.

**Root Cause**
The test `testExcludeJarFiles` has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. 

The test failed because it is trying to compare two strings, but the tested method uses `each` to go through a Collection generate a list, and then convert the list to a string. 
https://github.com/Rette66/gradle-duplicate-classes-check/blob/4754962bc8df030289c77f347f10790d600a27a8/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngine.groovy#L159-L166
The `each` method in Groovy is implemented in such a way that it does not go through every element in a Collection in a specific order. As a result, when the expected string(which is hard-coded) is compared with the actual one, it causes the failure.
https://github.com/Rette66/gradle-duplicate-classes-check/blob/4754962bc8df030289c77f347f10790d600a27a8/src/test/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngineTest.groovy#L84-L86

**Fix**
The test is fixed by sorting the list generated in the tested method before converting it to a string and changing the expected string to meet the sorting order. Therefore, the order of context in both the expected string and the generated string is the same. 

### How this has been tested?

1. Regular test - Successful
Command used -
```
./gradlew --info test --tests net.idlestate.gradle.duplicates.CheckDuplicateClassesEngineTest.testExcludeJarFiles
```

2. NonDex test - Failed
Command used -
```
./gradlew --info nondexTest --tests=net.idlestate.gradle.duplicates.CheckDuplicateClassesEngineTest.testExcludeJarFiles --nondexRuns=X
```
replace X with an int number
The NonDex test passed after the fix.

